### PR TITLE
Update existing comment instead of creating duplicates

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ const hasChanged = (before, after) => {
 
 // Template
 const changeComment = (data) => {
-  return `
+  return `<!-- FIGMA DIFF PROBOT -->
 | Before | After |
 | :-- | :-- |
 ${Object.values(data.before.components).map((b) => {

--- a/lib/find-existing-comment.js
+++ b/lib/find-existing-comment.js
@@ -1,0 +1,9 @@
+/**
+ * Returns the existing comment created by this app if it exists
+ */
+module.exports = async function findExistingComment (context) {
+  const comments = await context.github.issues.listComments(context.issue({ per_page: 100 }))
+  return comments.data.find(comment => {
+    return comment.user.type === 'Bot' && comment.body.startsWith('<!-- FIGMA DIFF PROBOT -->')
+  })
+}

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -4,7 +4,7 @@ exports[`figma-diff-probot creates a comment with a before and after image 1`] =
 Array [
   Array [
     Object {
-      "body": "
+      "body": "<!-- FIGMA DIFF PROBOT -->
 | Before | After |
 | :-- | :-- |
 | **Name:** \`heart\`<br>**Description:** \`keywords: love, beat\`  [<img src=\\"https://images.com/before\\" height=\\"200\\"/>](https://images.com/before) | **Name:** \`heart\`<br>**Description:** \`keywords: love, beat\`  [<img src=\\"https://images.com/after\\" height=\\"200\\"/>](https://images.com/after) |",

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -15,3 +15,20 @@ Array [
   ],
 ]
 `;
+
+exports[`figma-diff-probot updates the existing comment 1`] = `
+Array [
+  Array [
+    Object {
+      "body": "<!-- FIGMA DIFF PROBOT -->
+| Before | After |
+| :-- | :-- |
+| **Name:** \`heart\`<br>**Description:** \`keywords: love, beat\`  [<img src=\\"https://images.com/before\\" height=\\"200\\"/>](https://images.com/before) | **Name:** \`heart\`<br>**Description:** \`keywords: love, beat\`  [<img src=\\"https://images.com/after\\" height=\\"200\\"/>](https://images.com/after) |",
+      "comment_id": undefined,
+      "number": 1,
+      "owner": "primer",
+      "repo": "octicons",
+    },
+  ],
+]
+`;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -27,7 +27,8 @@ describe('figma-diff-probot', () => {
         get: jest.fn(() => Promise.resolve({ data: diff }))
       },
       issues: {
-        createComment: jest.fn()
+        createComment: jest.fn(),
+        listComments: jest.fn(() => Promise.resolve({ data: [] }))
       }
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -28,7 +28,8 @@ describe('figma-diff-probot', () => {
       },
       issues: {
         createComment: jest.fn(),
-        listComments: jest.fn(() => Promise.resolve({ data: [] }))
+        listComments: jest.fn(() => Promise.resolve({ data: [] })),
+        editComment: jest.fn()
       }
     }
 
@@ -69,6 +70,17 @@ describe('figma-diff-probot', () => {
 
     expect(github.issues.createComment).toHaveBeenCalled()
     expect(github.issues.createComment.mock.calls).toMatchSnapshot()
+  })
+
+  it('updates the existing comment', async () => {
+    github.issues.listComments.mockReturnValueOnce(Promise.resolve({ data: [
+      { user: { type: 'Bot' }, body: '<!-- FIGMA DIFF PROBOT --> Hi!' }
+    ] }))
+    await robot.receive(event)
+
+    expect(github.issues.createComment).not.toHaveBeenCalled()
+    expect(github.issues.editComment).toHaveBeenCalled()
+    expect(github.issues.editComment.mock.calls).toMatchSnapshot()
   })
 
   it('does not create a comment if there are no differences', async () => {

--- a/test/lib/find-existing-comment.test.js
+++ b/test/lib/find-existing-comment.test.js
@@ -1,0 +1,28 @@
+const findExistingComment = require('../../lib/find-existing-comment')
+
+describe('findExistingComment', () => {
+  let context
+
+  beforeEach(() => {
+    context = {
+      issue: o => ({ owner: 'primer', repo: 'basecoat', number: 1, ...o }),
+      github: { issues: { listComments: jest.fn() } }
+    }
+  })
+
+  it('returns the comment', async () => {
+    const comments = [
+      { user: { type: 'User' }, body: 'Test' },
+      { user: { type: 'Bot' }, body: '<!-- FIGMA DIFF PROBOT --> Magic!' }
+    ]
+    context.github.issues.listComments.mockReturnValueOnce(Promise.resolve({ data: comments }))
+    const actual = await findExistingComment(context)
+    expect(actual).toEqual(comments[1])
+  })
+
+  it('returns `undefined` if the comment does not exist', async () => {
+    context.github.issues.listComments.mockReturnValueOnce(Promise.resolve({ data: [] }))
+    const actual = await findExistingComment(context)
+    expect(actual).toBe(undefined)
+  })
+})


### PR DESCRIPTION
Sometimes, multiple changes in a PR can cause the app to generate a bunch of comments. This PR does a check for an existing comment by this app, then edits that comment with the new body (or creates a new comment).

One oddity worth noting - the GitHub API doesn't show the app's ID on the comments' user object 😞 so there are basically two options: hard-code the `login` of the app (`figma-diff-probot[bot]`) or use some other identifier. I've added an HTML comment to the beginning of the comment body that the app uses, to basically say "Yep this comment is mine". Hope that makes sense!

Let me know if you have any questions, or if something needs changes 👍 